### PR TITLE
Default Tax settings not applied

### DIFF
--- a/Develappers.BillomatNet/Mapping/InvoiceItemMapper.cs
+++ b/Develappers.BillomatNet/Mapping/InvoiceItemMapper.cs
@@ -90,7 +90,7 @@ namespace Develappers.BillomatNet.Mapping
                 Quantity = value.Quantity.ToString(CultureInfo.InvariantCulture),
                 UnitPrice = value.UnitPrice.ToString(CultureInfo.InvariantCulture),
                 TaxName = value.TaxName,
-                TaxRate = value.TaxRate.ToString(),
+                TaxRate = value.TaxRate?.ToString(),
                 Title = value.Title,
                 Description = value.Description,
                 TotalGross = value.TotalGross.ToString(CultureInfo.InvariantCulture),


### PR DESCRIPTION
Fixed Bug, that caused the backend of Billomat not to apply default Tax settings.

fixes #293 